### PR TITLE
Use absolute import

### DIFF
--- a/pymdstat/__init__.py
+++ b/pymdstat/__init__.py
@@ -11,4 +11,6 @@ __version__ = "0.2"
 __author__ = "Nicolas Hennion <nicolas@nicolargo.com>"
 __licence__ = "MIT"
 
-from pymdstat import MdStat
+__all__ = ['MdStat']
+
+from .pymdstat import MdStat

--- a/pymdstat/pymdstat.py
+++ b/pymdstat/pymdstat.py
@@ -6,14 +6,8 @@
 #
 # Copyright (C) 2014 Nicolargo <nicolas@nicolargo.com>
 
+from functools import reduce
 from re import split
-try:
-    from functools import reduce
-except:
-    pass
-
-# Limit import to class...
-__all__ = ['MdStat']
 
 
 # Classes


### PR DESCRIPTION
Relative imports prevents pymdstat working on Python 3.

Remove redundant check for functools.reduce(). It was introduced in Python 2.6.
