### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ PyMDstat
         :target: https://scrutinizer-ci.com/g/nicolargo/pymdstat/?branch=master
 .. image:: https://scrutinizer-ci.com/g/nicolargo/pymdstat/badges/quality-score.png?b=master
         :target: https://scrutinizer-ci.com/g/nicolargo/pymdstat/?branch=master
-.. image:: https://pypip.in/version/pymdstat/badge.svg
+.. image:: https://img.shields.io/pypi/v/pymdstat.svg
     :target: https://pypi.python.org/pypi/pymdstat/
     :alt: Latest Version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pymdstat))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pymdstat`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.